### PR TITLE
Add overloads for the AppBuilderExtensions to allow passing in of the HttpConfiguration

### DIFF
--- a/source/DD4T.RestService.WebApi/AppBuilderExtensions.cs
+++ b/source/DD4T.RestService.WebApi/AppBuilderExtensions.cs
@@ -26,9 +26,21 @@ namespace DD4T.RestService.WebApi
             var builder = new ContainerBuilder();
             appBuilder.UseDD4TWebApi(builder);
         }
+
+        public static void UseDD4TWebApi(this IAppBuilder appBuilder, HttpConfiguration config)
+        {
+            var builder = new ContainerBuilder();
+            appBuilder.UseDD4TWebApi(builder, config);
+        }
+
         public static void UseDD4TWebApi(this IAppBuilder appBuilder, ContainerBuilder builder)
         {
             var config = new HttpConfiguration();
+            appBuilder.UseDD4TWebApi(builder, config);
+        }
+
+        public static void UseDD4TWebApi(this IAppBuilder appBuilder, ContainerBuilder builder, HttpConfiguration config)
+        {
             builder.RegisterApiControllers(typeof(AppBuilderExtensions).Assembly);
             builder.UseDD4T();
 


### PR DESCRIPTION
This allows the `app.UseDD4TWebApi` to have the `HttpConfiguration` passed in for additional customising of the application.
